### PR TITLE
Allow entering an input file, for example for creating a new job

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ docker run -it --rm \
   dcycle/docker-jenkins-cli create-job my-new-job
 ```
 
+Redirect output and/or errors:
+
+```
+...
+  -e "OUTPUT_FILE=/path/to/my/output.log" \
+  -e "ERROR_FILE=/path/to/my/error.log" \
+...
+```
+
 Replace `help` with your jenkin-cli command. See [Jenkins CLI wiki page](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI) for more information.
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ docker run -it --rm \
   chickenzord/jenkins-cli help
 ```
 
+With auth and and XML file as input, for example to create a new project:
+
+```
+docker run -it --rm \
+  -v $HOME/.ssh:/ssh \
+  -v $(pwd)/path/to/my/xml/files:/my-xml \
+  -e "JENKINS_URL=http://jenkins.example.com:8080" \
+  -e "INPUT_FILE=/my-xml/my-job-description.xml" \
+  chickenzord/jenkins-cli create-job my-new-job
+```
+
 Replace `help` with your jenkin-cli command. See [Jenkins CLI wiki page](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI) for more information.
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run -it --rm \
   -v $(pwd)/path/to/my/xml/files:/my-xml \
   -e "JENKINS_URL=http://jenkins.example.com:8080" \
   -e "INPUT_FILE=/my-xml/my-job-description.xml" \
-  chickenzord/jenkins-cli create-job my-new-job
+  dcycle/docker-jenkins-cli create-job my-new-job
 ```
 
 Replace `help` with your jenkin-cli command. See [Jenkins CLI wiki page](https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI) for more information.

--- a/jenkins-cli-wrapper.sh
+++ b/jenkins-cli-wrapper.sh
@@ -15,9 +15,17 @@ else
     wget "$JENKINS_URL/jnlpJars/jenkins-cli.jar" -q -O "$cli_jar"
   fi
 
-  if [ -f "$PRIVATE_KEY" ]; then
-    java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@"
+  if [ -f "$INPUT_FILE" ]; then
+    if [ -f "$PRIVATE_KEY" ]; then
+      java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@" < "$INPUT_FILE"
+    else
+      java -jar "$cli_jar" -s $JENKINS_URL "$@" < "$INPUT_FILE"
+    fi
   else
-    java -jar "$cli_jar" -s $JENKINS_URL "$@"
+    if [ -f "$PRIVATE_KEY" ]; then
+      java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@"
+    else
+      java -jar "$cli_jar" -s $JENKINS_URL "$@"
+    fi
   fi
 fi

--- a/jenkins-cli-wrapper.sh
+++ b/jenkins-cli-wrapper.sh
@@ -15,17 +15,28 @@ else
     wget "$JENKINS_URL/jnlpJars/jenkins-cli.jar" -q -O "$cli_jar"
   fi
 
+  if [ -z "$OUTPUT_FILE" ]; then
+      STDOUT=/dev/stdout
+  fi
+  if [ -z "$ERROR_FILE" ]; then
+      STDOUT=/dev/stderr
+  fi
+
   if [ -f "$INPUT_FILE" ]; then
     if [ -f "$PRIVATE_KEY" ]; then
-      java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@" < "$INPUT_FILE"
+      java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@" < $INPUT_FILE \
+      > "$OUTPUT_FILE" 2> "$ERROR_FILE"
     else
-      java -jar "$cli_jar" -s $JENKINS_URL "$@" < "$INPUT_FILE"
+      java -jar "$cli_jar" -s $JENKINS_URL "$@" < $INPUT_FILE \
+      > "$OUTPUT_FILE" 2> "$ERROR_FILE"
     fi
   else
     if [ -f "$PRIVATE_KEY" ]; then
-      java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@"
+      java -jar "$cli_jar" -s $JENKINS_URL -i $PRIVATE_KEY "$@" \
+      > "$OUTPUT_FILE" 2> "$ERROR_FILE"
     else
-      java -jar "$cli_jar" -s $JENKINS_URL "$@"
+      java -jar "$cli_jar" -s $JENKINS_URL "$@" \
+      > "$OUTPUT_FILE" 2> "$ERROR_FILE"
     fi
   fi
 fi


### PR DESCRIPTION
I suggest modifying jenkins-cli-wrapper.sh slightly to take into account the possibility of importing an xml file, I did not manage to do it any other way, see #1.
